### PR TITLE
fix: set up TypeScript path aliases to resolve import errors

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -8,7 +8,11 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "/src/*": ["src/*"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
 }


### PR DESCRIPTION
An import error appears in the IDE, so I added path aliases settings as a workaround for the issue.

#### the error appears on `training/2nd/start`:
<img width="781" alt="image" src="https://github.com/user-attachments/assets/c3290d8e-5a24-4c98-8da9-1e36b770f313" />

#### the error has been fixed on `feature/training/2nd/start/fix_import_issue`
<img width="613" alt="image" src="https://github.com/user-attachments/assets/0256be69-5cb7-43e6-a165-6d3cc6fa85f3" />
